### PR TITLE
Update to `jupyterlite-core==0.1.0b20`

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,8 +1,0 @@
-{
-    "jupyter-lite-schema-version": 0,
-    "jupyter-config-data": {
-      "disabledExtensions": [
-        "@jupyterlite/javascript-kernel-extension"
-      ]
-    }
-  }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-fasta>=3,<4
 jupyterlab-geojson>=3,<4
 jupyterlab-tour
 jupyterlab_miami_nights
-jupyterlite-core==0.1.0b19
+jupyterlite-core==0.1.0b20
 jupyterlite-pyodide-kernel==0.0.5
 plotly>=5,<6
 jupyterlab-night


### PR DESCRIPTION
Follow-up to #1 

Update to the latest JupyterLite release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

Which removed the JavaScript kernel from the main bundle: https://github.com/jupyterlite/jupyterlite/pull/1013

This means the `jupyter-lite-.json` file should not be needed anymore.